### PR TITLE
ENG-1: refine Docker build workflow for API docs deployment

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-env:
-  IMAGE_NAME: payangel-api-docs
-  KUBE_NAMESPACE: documentation
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -24,14 +20,13 @@ jobs:
           password: ${{ secrets.AZURE_REGISTRY_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Generate Build ID
-        id: build-id
-        run: echo "::set-output name=id::$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA::8}"
+        run: echo "id=$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v3
@@ -39,10 +34,10 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.AZURE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ secrets.AZURE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.build-id.outputs.id }}
-          cache-from: type=registry,ref=${{ secrets.AZURE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-to: type=inline
+            ${{ secrets.AZURE_REGISTRY }}/payangel-api-docs:latest
+            ${{ secrets.AZURE_REGISTRY }}/payangel-api-docs:${{ steps.build-id.outputs.id }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
 # - name: Set up kubectl
 #   uses: azure/k8s-set-context@v3


### PR DESCRIPTION
- Remove unused environment variables `IMAGE_NAME` and `KUBE_NAMESPACE`
- Upgrade `docker/setup-qemu-action` from v2 to v3 for improved QEMU setup
- Replace deprecated `set-output` command with new syntax for setting `build-id`
- Use explicit image name `payangel-api-docs` directly in tags instead of environment variable
- Change Docker build cache strategy from registry-based to GitHub Actions cache (`type=gha`) for better performance and reliability